### PR TITLE
Add timezones

### DIFF
--- a/src/TimeZone.js
+++ b/src/TimeZone.js
@@ -11,4 +11,6 @@ exports._format = timezone => dateTime => formatter =>
 exports._offset = timezone => dateTime =>
   Moment(dateTime).tz(timezone).utcOffset();
 
+exports.timezones = Moment.tz.names();
+
 exports.validate = name => Moment.tz.zone(name) !== null;

--- a/src/TimeZone.purs
+++ b/src/TimeZone.purs
@@ -7,6 +7,7 @@ module TimeZone
   , name
   , pacific
   , timezone
+  , timezones
   , utc
   ) where
 
@@ -34,6 +35,8 @@ foreign import _abbr :: TimeZone -> String -> String
 foreign import _format :: TimeZone -> String -> String -> String
 
 foreign import _offset :: TimeZone -> String -> Number
+
+foreign import timezones :: Array TimeZone
 
 foreign import validate :: String -> Boolean
 


### PR DESCRIPTION
In order to replace the version of this library copied into Wildcat we need to provide access to the list of timezones that Moment provides.